### PR TITLE
Testing for the closeScope0 function

### DIFF
--- a/runtime/jcl/common/jdk_internal_misc_ScopedMemoryAccess.cpp
+++ b/runtime/jcl/common/jdk_internal_misc_ScopedMemoryAccess.cpp
@@ -39,6 +39,7 @@ Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives(JNIEnv *env, jclass cl
 static UDATA
 closeScope0FrameWalkFunction(J9VMThread *vmThread, J9StackWalkState *walkState)
 {
+	printf("	Next frame\n");
 	if (JNI_FALSE == *(jboolean *)walkState->userData2) {
 		/* scope has been found */
 		return J9_STACKWALK_STOP_ITERATING;
@@ -99,6 +100,7 @@ Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0(JNIEnv *env, jobject insta
 			walkState.frameWalkFunction = closeScope0FrameWalkFunction;
 			walkState.objectSlotWalkFunction = closeScope0OSlotWalkFunction;
 
+			printf("Next thread\n");
 			vm->walkStackFrames(walkThread, &walkState);
 			if (JNI_FALSE == *(jboolean *)walkState.userData2) {
 				/* scope found */


### PR DESCRIPTION
Java command:
`build/linux-x86_64-server-release/images/jdk/bin/java
    --add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED
    --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
    --add-modules jdk.incubator.foreign Test.java`

Signed-off-by: Eric Yang <eric.yang@ibm.com>